### PR TITLE
feat: mount settings.toml inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN rustup default nightly && rustup update
 RUN apt install libssl-dev pkg-config
 
 WORKDIR /app
-# Make sure to have a settings.toml
 COPY Cargo.lock Cargo.toml ./
 COPY src ./src
 COPY templates ./templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@ FROM rust
 RUN rustup default nightly && rustup update
 RUN apt install libssl-dev pkg-config
 
+WORKDIR /app
 # Make sure to have a settings.toml
-COPY ./ ./
+COPY Cargo.lock Cargo.toml ./
+COPY src ./src
+COPY templates ./templates
 RUN cargo build --release
 
 RUN chmod +x ./target/release/aocleaderboard
-ENTRYPOINT [ "target/release/aocleaderboard" ]
+ENTRYPOINT [ "/app/target/release/aocleaderboard" ]

--- a/README.md
+++ b/README.md
@@ -112,17 +112,29 @@ leaderboards in order to fetch their data - check your leaderboards at
 
 ## Run
 
+### Running on bare metal
 Start the app:
+```console
+cargo run --release
+```
 
-```
-# cargo run --release
+### Docker
+Build the Docker image:
+```console
+docker build . -t aocleaderboard
 ```
 
-If you are using Docker Compose:
+Start the image:
+```console
+docker run -p 8000:8000 -v "$(pwd)/settings.toml:/app/settings.toml" aocleaderboard
 ```
-docker-compose up
+This will mount the `settings.toml` file into the container. 
+
+### Docker Compose
+```console
+docker compose up
 # Or, for detached
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - 8000:8000
     build:
       context: .
+    volumes:
+      - ./settings.toml:/app/settings.toml


### PR DESCRIPTION
Hello @scarvalhojr!

As done prior to this commit, every time a configuration change was necessary it required a rebuild of the Docker image.

With this PR, that is now done instead with a volume mount by mounting `settings.toml` at `/app/settings.toml` inside the container.

I've also updated the documentation.