### PR TITLE
Fix: Added specific rust version for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust
 
-RUN rustup default nightly && rustup update
+RUN rustup toolchain install nightly-2022-11-30
+RUN rustup default nightly-22-11-30 && rustup update
 RUN apt install libssl-dev pkg-config
 
 WORKDIR /app


### PR DESCRIPTION
This is not to be taken as a total fix, this is just a temporal patch while someone sits down and fixes the underlying issues regarding the incompatibility with modern rust versions.